### PR TITLE
[context] make query string part of image_url again (like v5.2.1)

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -267,11 +267,21 @@ class RequestParametersTestCase(TestCase):
             path='/test.jpg',
             headers={
                 'Accept': 'image/webp',
-            }
+            },
+            query=None
         )
         params = RequestParameters(request=request, image='/test.jpg')
         expect(params.accepts_webp).to_be_true()
         expect(params.image_url).to_equal('/test.jpg')
+
+    def test_can_get_params_from_request_with_query(self):
+        request = mock.Mock(
+            path='/test.jpg',
+            headers={},
+            query='ts=12345'
+        )
+        params = RequestParameters(request=request, image='/test.jpg')
+        expect(params.image_url).to_equal('/test.jpg?ts=12345')
 
 
 class ContextImporterTestCase(TestCase):

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -195,6 +195,8 @@ class RequestParameters:
         self.max_age = max_age
 
         if request:
+            if request.query:
+                self.image_url += '?%s' % request.query
             self.url = request.path
             self.accepts_webp = 'image/webp' in request.headers.get('Accept', '')
 


### PR DESCRIPTION
[context] make query string part of image_url again (like v5.2.1)